### PR TITLE
Fix static lua path in documentation scripts

### DIFF
--- a/util/data2html.lua
+++ b/util/data2html.lua
@@ -1,4 +1,4 @@
-#!/usr/local/bin/lua
+#!/usr/bin/env lua
 
 -- Parse a lua table in modules/data and write text
 -- to run: lua sp.lua "foo"

--- a/util/gen_index.lua
+++ b/util/gen_index.lua
@@ -1,4 +1,4 @@
-#!/usr/local/bin/lua
+#!/usr/bin/env lua
 
 file = io.open(arg[1])
 io.write("<html>\n")


### PR DESCRIPTION
Ensure that any system with `lua` installed can build the docs.