### PR TITLE
Update libsndfile install instructions for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,15 @@ By default, Soundpipe needs libsndfile, and a standard build environment.
 Other modules that use other external libraries will need to be explicitly compiled
 by modififying config.mk.
 
-If you are using a Mac, clone and build from the libsndfile repository here 
-located here: https://github.com/erikd/libsndfile/
+If you are using a Mac you can install libsndfile via
+[Homebrew](http://brew.sh/):
+
+```sh
+$ brew install libsndfile
+```
+
+Alternatively, clone and build from the [libsndfile
+repository](https://github.com/erikd/libsndfile/).
 
 On Linux, the libsndfile-dev package will need to be installed.
 
@@ -95,6 +102,3 @@ a pull-request.
 
 Additionally, if you'd like to contribute bys adding more modules to Soundpipe, please 
 see the Style Guide (util/style\_guide.md) and the Module How-To Guide (util/module\_howto.md).
-
-
-


### PR DESCRIPTION
I updated the `README.md` to recommend Homebrew for installing libsndfile because it's easier and has widespread developer adoption.