### PR TITLE
Proposal for making Soundpipe able to handle SPFLOAT=double

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,13 @@ MPATHS += $(addprefix $(MODDIR)/, $(addsuffix .o, $(MODULES)))
 
 include $(CONFIG)
 
+ifeq ($(USE_DOUBLE), 1)
+CFLAGS+=-DUSE_DOUBLE
+SPFLOAT=double
+else
+SPFLOAT=float
+endif
+
 CFLAGS += -DSP_VERSION=$(VERSION) -O3 -DSPFLOAT=${SPFLOAT} -std=c99
 CFLAGS += -I$(INTERMEDIATES_PREFIX)/h -Ih -I/usr/local/include -fPIC
 UTIL += $(INTERMEDIATES_PREFIX)/util/wav2smp

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ MPATHS += $(addprefix $(MODDIR)/, $(addsuffix .o, $(MODULES)))
 
 include $(CONFIG)
 
-CFLAGS += -DSP_VERSION=$(VERSION) -O3 -DSPFLOAT=float -std=c99
+CFLAGS += -DSP_VERSION=$(VERSION) -O3 -DSPFLOAT=${SPFLOAT} -std=c99
 CFLAGS += -I$(INTERMEDIATES_PREFIX)/h -Ih -I/usr/local/include -fPIC
 UTIL += $(INTERMEDIATES_PREFIX)/util/wav2smp
 

--- a/config.def.mk
+++ b/config.def.mk
@@ -150,4 +150,4 @@ include lib/spa/Makefile
 CFLAGS += -DUSE_SPA
 
 CFLAGS += -fPIC -g
-SPFLOAT=float
+USE_DOUBLE=1

--- a/config.def.mk
+++ b/config.def.mk
@@ -150,4 +150,6 @@ include lib/spa/Makefile
 CFLAGS += -DUSE_SPA
 
 CFLAGS += -fPIC -g
-USE_DOUBLE=1
+
+# Uncomment this to use double precision
+#USE_DOUBLE=1

--- a/config.def.mk
+++ b/config.def.mk
@@ -150,3 +150,4 @@ include lib/spa/Makefile
 CFLAGS += -DUSE_SPA
 
 CFLAGS += -fPIC -g
+SPFLOAT=float

--- a/lib/kissfft/Makefile
+++ b/lib/kissfft/Makefile
@@ -1,5 +1,5 @@
 LPATHS += $(LIBDIR)/kissfft/kiss_fft.o $(LIBDIR)/kissfft/kiss_fftr.o
-CFLAGS += -Ilib/kissfft/ -Dkiss_fft_scalar=float
+CFLAGS += -Ilib/kissfft/ -Dkiss_fft_scalar=${SPFLOAT}
 
 $(LIBDIR)/kissfft:
 	mkdir -p $@

--- a/lib/kissfft/Makefile
+++ b/lib/kissfft/Makefile
@@ -1,5 +1,5 @@
 LPATHS += $(LIBDIR)/kissfft/kiss_fft.o $(LIBDIR)/kissfft/kiss_fftr.o
-CFLAGS += -Ilib/kissfft/ -Dkiss_fft_scalar=${SPFLOAT}
+CFLAGS += -Ilib/kissfft/ -Dkiss_fft_scalar=$(SPFLOAT)
 
 $(LIBDIR)/kissfft:
 	mkdir -p $@

--- a/modules/base.c
+++ b/modules/base.c
@@ -80,7 +80,11 @@ int sp_process(sp_data *sp, void *ud, void (*callback)(sp_data *, void *))
             sp->pos++;
         }
         for(chan = 0; chan < sp->nchan; chan++) {
+#ifdef USE_DOUBLE
+            sf_write_double(sf[chan], buf[chan], numsamps);
+#else
             sf_write_float(sf[chan], buf[chan], numsamps);
+#endif
         }
         sp->len -= numsamps;
     }

--- a/modules/diskin.c
+++ b/modules/diskin.c
@@ -48,7 +48,11 @@ int sp_diskin_init(sp_data *sp, sp_diskin *p, const char *filename)
 int sp_diskin_compute(sp_data *sp, sp_diskin *p, SPFLOAT *in, SPFLOAT *out)
 {
     if(p->bufpos == 0 && p->loaded && p->count > 0) {
+#ifdef USE_DOUBLE
+        p->count = sf_read_double(p->file, p->buffer, p->count);
+#else
         p->count = sf_read_float(p->file, p->buffer, p->count);
+#endif
     } 
 
     if(p->count <= 0) {

--- a/modules/ftbl.c
+++ b/modules/ftbl.c
@@ -93,7 +93,11 @@ int sp_gen_file(sp_data *sp, sp_ftbl *ft, const char *filename)
     memset(&info, 0, sizeof(SF_INFO));
     info.format = 0;
     SNDFILE *snd = sf_open(filename, SFM_READ, &info);
+#ifdef USE_DOUBLE
+    sf_readf_double(snd, ft->tbl, ft->size);
+#else
     sf_readf_float(snd, ft->tbl, ft->size);
+#endif
     sf_close(snd);
     return SP_OK;
 }
@@ -118,7 +122,11 @@ int sp_ftbl_loadfile(sp_data *sp, sp_ftbl **ft, const char *filename)
     ftp->lomask = (2^ftp->lobits) - 1;
     ftp->lodiv = 1.0 / pow(2, ftp->lobits);
 
+#ifdef USE_DOUBLE
+    sf_readf_double(snd, ftp->tbl, ftp->size);
+#else
     sf_readf_float(snd, ftp->tbl, ftp->size);
+#endif
     sf_close(snd);
     return SP_OK;
 }

--- a/modules/nsmp.c
+++ b/modules/nsmp.c
@@ -22,7 +22,7 @@ int nano_ini_handler(void *user, const char *section, const char *name,
 {
     nanosamp *ss = user;
     nano_dict *dict = &ss->dict;
-    const char *entry_name = dict->last->name; 
+    const char *entry_name = dict->last->name;
 
     if(dict->init) {
         nano_dict_add(dict, section);
@@ -98,7 +98,7 @@ int nano_select(nanosamp *smp, const char *keyword)
             break;
         } else {
             entry = entry->next;
-        } 
+        }
     }
 
     if(smp->selected == 1) return SP_OK;
@@ -106,13 +106,12 @@ int nano_select(nanosamp *smp, const char *keyword)
 }
 
 
-int nano_compute(sp_data *sp, nanosamp *smp, float *out)
+int nano_compute(sp_data *sp, nanosamp *smp, SPFLOAT *out)
 {
     if(!smp->selected) {
         *out = 0;
-        return SP_NOT_OK; 
+        return SP_NOT_OK;
     }
-    
 
     if(smp->curpos < (SPFLOAT)smp->sample->size) {
         SPFLOAT x1 = 0 , x2 = 0, frac = 0, tmp = 0;
@@ -125,7 +124,7 @@ int nano_compute(sp_data *sp, nanosamp *smp, float *out)
         if(index >= smp->ft->size) {
             index = smp->ft->size - 1;
         }
-        
+
         x1 = tbl[index];
         x2 = tbl[index + 1];
         *out = x1 + (x2 - x1) * frac;
@@ -169,7 +168,7 @@ int nano_create_index(nanosamp *smp)
     int i;
     nano_entry *entry, *next;
     entry = dict->root.next;
-    
+
     for(i = 0; i < dict->nval; i++) {
         next = entry->next;
         smp->index[i] = entry;
@@ -216,7 +215,7 @@ int sp_nsmp_init(sp_data *sp, sp_nsmp *p, sp_ftbl *ft, int sr, const char *ini)
 int sp_nsmp_compute(sp_data *sp, sp_nsmp *p, SPFLOAT *trig, SPFLOAT *out)
 {
     if (*trig != 0) {
-       p->triggered = 1; 
+       p->triggered = 1;
        nano_select_from_index(p->smp, p->index);
     }
 


### PR DESCRIPTION
while working on [this](https://github.com/fennecdjay/Gwion/issues/5) issue,
I ended up:
- fixing _nano_compute_ to use SPFLOAT.
- defining a SPFLOAT variable in config.def.mk (use float by default)
- defining sf_read/readf/write functions in Makefile, to use them in base.c, ftbl.c, diskin.c.

Tell me if this a correct way of doing this.
works flawlessly on my platform.
