### PR TITLE
Remove linker options from CFLAGS

### DIFF
--- a/config.def.mk
+++ b/config.def.mk
@@ -141,19 +141,17 @@ include lib/fft/Makefile
 # JACK module
 #
 #MODULES += jack
-#CFLAGS += -ljack
 
 # RPi Module
 #
 #MODULES += rpi
-#CFLAGS += -lasound
 
 include lib/kissfft/Makefile
 MODULES += fftwrapper
 MODULES += padsynth
 
 # Uncomment to use FFTW3 instead of kissfft.
-# CFLAGS += -lfftw3 -DUSE_FFTW3
+# CFLAGS += -DUSE_FFTW3
 
 # Soundpipe audio 
 include lib/spa/Makefile


### PR DESCRIPTION
e.g. clang complains about this when compiling on OS X