### PR TITLE
Corrected direct gcc call to $(CC) in Makefile

### DIFF
--- a/lib/spa/Makefile
+++ b/lib/spa/Makefile
@@ -6,4 +6,4 @@ $(LIBDIR)/spa:
 	mkdir -p $@
 
 $(LIBDIR)/spa/spa.o: lib/spa/spa.c | $(LIBDIR)/spa
-	gcc $(CFLAGS) $< -c -o $@
+	$(CC) $(CFLAGS) $< -c -o $@


### PR DESCRIPTION
The direct use of gcc was preventing cross-compilation for arm.