### PR TITLE
ex_fosc.c fix - ensure UserData pointer is set

### DIFF
--- a/examples/ex_fosc.c
+++ b/examples/ex_fosc.c
@@ -10,7 +10,7 @@ typedef struct {
 } UserData;
 
 void process(sp_data *sp, void *udata) {
-    UserData *ud = ud;
+    UserData *ud = udata;
     if(ud->counter == 0){
         ud->osc->freq = 500 + rand() % 2000;
     }


### PR DESCRIPTION
Hi! I was looking at Soundpipe and had a segfault when running the `ex_fosc.c` example. Turns out the UserData pointer is set to itself, instead of `*udata`. Easy enough to fix!